### PR TITLE
Fix documentation to put this pkg into can-ecosystem

### DIFF
--- a/can-super-model.md
+++ b/can-super-model.md
@@ -1,6 +1,6 @@
 @module {function} can-super-model
 @parent can-data-modeling
-@collection can-core
+@collection can-ecosystem
 @outline 2
 
 @description Connect a type to a restful data source, automatically manage


### PR DESCRIPTION
can-super-model is an ecosystem package but is listed on the website as
core. This fixes that.