### PR TITLE
Add a new signature (just pass in a string) and use can-define to set up List and Map if they’re not passed in

### DIFF
--- a/can-super-model-test.js
+++ b/can-super-model-test.js
@@ -189,3 +189,10 @@ QUnit.test("passes queryLogic", function(){
 
     QUnit.equal(connection.queryLogic, ql, "same query logic");
 });
+
+QUnit.test("string signature", function(assert) {
+    var connection = superModel("/api/todos/{_id}");
+
+    assert.ok(new connection.Map() instanceof DefineMap, "Map defined");
+    assert.ok(new connection.List() instanceof DefineList, "List defined");
+});

--- a/can-super-model.js
+++ b/can-super-model.js
@@ -13,11 +13,25 @@ var dataUrl = require("can-connect/data/url/url");
 var fallThroughCache = require("can-connect/fall-through-cache/fall-through-cache");
 var realTime = require("can-connect/real-time/real-time");
 var callbacksOnce = require("can-connect/constructor/callbacks-once/callbacks-once");
+var DefineList = require("can-define/list/list");
+var DefineMap = require("can-define/map/map");
 var namespace = require("can-namespace");
 var canReflect = require("can-reflect");
 var QueryLogic = require("can-query-logic");
 
-function superModel(options){
+function superModel(optionsOrUrl) {
+
+	// If optionsOrUrl is a string, make options = {url: optionsOrUrl}
+	var options = (typeof optionsOrUrl === "string") ? {url: optionsOrUrl} : optionsOrUrl;
+
+	// If options.Map or .List aren’t provided, define them
+	if (typeof options.Map === "undefined") {
+		options.Map = DefineMap.extend({seal: false}, {});
+	}
+	if (typeof options.List === "undefined") {
+		options.List = options.Map.List || DefineList.extend({"#": options.Map});
+	}
+
     options = canReflect.assignDeep({},options);
 
     if(!options.name) {

--- a/can-super-model.md
+++ b/can-super-model.md
@@ -1,6 +1,7 @@
 @module {function} can-super-model
 @parent can-data-modeling
 @collection can-ecosystem
+@package ./package.json
 @outline 2
 
 @description Connect a type to a restful data source, automatically manage
@@ -95,6 +96,37 @@ const todoConnection = superModel({
 
 @return {connection} A connection that is the combination of the options and all the behaviors
 that `superModel` adds.
+
+@signature `superModel(url)`
+
+Create a connection with just a url. Use this if you do not need to pass in any other `options` to configure the connection.
+
+For example, the following creates a `Todo` type with the ability to connect to a restful service layer:
+
+```js
+import {todoFixture} from "//unpkg.com/can-demo-models@5";
+import {superModel} from "can";
+
+// Creates a mock backend with 5 todos
+todoFixture(5);
+
+const Todo = superModel("/api/todos/{id}").Map;
+
+// Prints out all todo names
+Todo.getList().then(todos => {
+    todos.forEach(todo => {
+        console.log(todo.name);
+    })
+})
+```
+  @codepen
+
+@param {String} url The [can-connect/data/url/url.url] used to create, retrieve, update and
+  delete data.
+
+@return {connection} A connection that is the combination of the options and all the behaviors
+that `superModel` adds. The `connection` includes a `Map` property which is the type
+constructor function used to create instances of the raw record data retrieved from the server.
 
 
 @body

--- a/package.json
+++ b/package.json
@@ -41,15 +41,15 @@
     ]
   },
   "dependencies": {
-    "can-connect": "^3.0.0-pre.3",
+    "can-connect": "^3.0.0",
+    "can-define": "^2.2.0",
     "can-globals": "^1.0.1",
     "can-namespace": "^1.0.0",
     "can-query-logic": "<2.0.0",
     "can-reflect": "^1.15.2"
   },
   "devDependencies": {
-    "can-fixture": "^3.0.0-pre.3",
-    "can-define": "^2.2.0",
+    "can-fixture": "^3.0.0",
     "jshint": "^2.9.1",
     "steal": "^1.6.5",
     "steal-qunit": "^1.0.1",


### PR DESCRIPTION
This makes the following possible:

```js
const Todo = superModel("/api/todos/{id}").Map;
```

- Pass in just a string to `superModel()` to configure the connection
- If `Map` or `List` aren’t defined in the options, then `can-define` is used by default

Closes https://github.com/canjs/can-super-model/issues/2

Here’s the new signature:
<img width="942" alt="screen shot 2019-02-22 at 2 40 20 pm" src="https://user-images.githubusercontent.com/10070176/53275423-ede69880-36af-11e9-9b6e-58239cc38a5b.png">
